### PR TITLE
ActiveSupport 3 compatibility change

### DIFF
--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -1,5 +1,6 @@
 require 'uri'
 require 'cgi'
+require 'logger'
 require 'net/https'
 require 'rexml/document'
 


### PR DESCRIPTION
This gets RubyCAS-Client running (completely, I think, though it's hard to be totally sure of that) under ActiveSupport 3.

Related: http://groups.google.com/group/rubycas-server/browse_thread/thread/4edf936f5ee860af
