### PR TITLE
Uri escape ssout

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -278,8 +278,10 @@ module CASClient
             
             if controller.request.post? &&
                 controller.params['logoutRequest'] &&
-                controller.params['logoutRequest'] =~
-                  %r{^<samlp:LogoutRequest.*?<samlp:SessionIndex>(.*)</samlp:SessionIndex>}m
+                #This next line checks the logoutRequest value for both its regular and URI.escape'd form. I couldn't get
+                #it to work without URI.escaping it from rubycas server's side, this way it will work either way.
+                [controller.params['logoutRequest'],URI.unescape(controller.params['logoutRequest'])].find{|xml| xml =~
+                    %r{^<samlp:LogoutRequest.*?<samlp:SessionIndex>(.*)</samlp:SessionIndex>}m}
               # TODO: Maybe check that the request came from the registered CAS server? Although this might be
               #       pointless since it's easily spoofable...
               si = $~[1]


### PR DESCRIPTION
Hello,

This is part of a pair of commits, the other being to rubycas-server. You can read further details about the situation at the other pull request:
https://github.com/gunark/rubycas-server/pull/36
for the other commit:
https://github.com/jcwilk/rubycas-server/commit/6df235217cdc82b110834223a4d729afac12ff46

The [].first{} thing i did in there is a little odd, but basically it evaluates to true when one of them matches, and whichever one matched will be the regex capture... That way whether it's URI.escape'd or not it should work (that is, if the previous behavior of not URI.escaping ever worked).

-John
