### PR TITLE
Rails 3.1 compatibility

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -140,7 +140,13 @@ module CASClient
           
           def configure(config)
             @@config = config
-            @@config[:logger] = RAILS_DEFAULT_LOGGER unless @@config[:logger]
+            @@config[:logger] ||= begin
+              if defined?(Rails) && Rails.respond_to?(:logger)
+                Rails.logger
+              elsif defined?(RAILS_DEFAULT_LOGGER)
+                RAILS_DEFAULT_LOGGER
+              end
+            end
             @@client = CASClient::Client.new(config)
             @@log = client.log
           end


### PR DESCRIPTION
`RAILS_DEFAULT_LOGGER` has been deprecated since 3.0 and has been removed in 3.1. Without this patch, this library is not compatible with Rails 3.1.
