### PR TITLE
authenticate_on_every_request should also validate on every request

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -32,27 +32,28 @@ module CASClient
 
             st = read_ticket(controller)
             
-            if st && last_st && 
-                last_st == st.ticket && 
-                last_st_service == st.service
-              # warn() rather than info() because we really shouldn't be re-validating the same ticket. 
-              # The only situation where this is acceptable is if the user manually does a refresh and 
-              # the same ticket happens to be in the URL.
-              log.warn("Re-using previously validated ticket since the ticket id and service are the same.")
-              return true
-            elsif last_st &&
-                !config[:authenticate_on_every_request] && 
-                controller.session[client.username_session_key]
-              # Re-use the previous ticket if the user already has a local CAS session (i.e. if they were already
-              # previously authenticated for this service). This is to prevent redirection to the CAS server on every
-              # request.
-              #
-              # This behaviour can be disabled (so that every request is routed through the CAS server) by setting
-              # the :authenticate_on_every_request config option to true. However, this is not desirable since
-              # it will almost certainly break POST request, AJAX calls, etc.
-              log.debug "Existing local CAS session detected for #{controller.session[client.username_session_key].inspect}. "+
-                "Previous ticket #{last_st.inspect} will be re-used."
-              return true
+            unless config[:authenticate_on_every_request]
+              if st && last_st && 
+                  last_st == st.ticket && 
+                  last_st_service == st.service
+                # warn() rather than info() because we really shouldn't be re-validating the same ticket. 
+                # The only situation where this is acceptable is if the user manually does a refresh and 
+                # the same ticket happens to be in the URL.
+                log.warn("Re-using previously validated ticket since the ticket id and service are the same.")
+                return true
+              elsif last_st &&
+                  controller.session[client.username_session_key]
+                # Re-use the previous ticket if the user already has a local CAS session (i.e. if they were already
+                # previously authenticated for this service). This is to prevent redirection to the CAS server on every
+                # request.
+                #
+                # This behaviour can be disabled (so that every request is routed through the CAS server) by setting
+                # the :authenticate_on_every_request config option to true. However, this is not desirable since
+                # it will almost certainly break POST request, AJAX calls, etc.
+                log.debug "Existing local CAS session detected for #{controller.session[client.username_session_key].inspect}. "+
+                  "Previous ticket #{last_st.inspect} will be re-used."
+                return true
+              end
             end
             
             if st


### PR DESCRIPTION
I was about to add a new config option, but i thought it would be simpler
to assume tickets also have to be validated on every request when
authenticate_on_every_request is set to true
