### PR TITLE
use Net::HTTP::Proxy and allow configuration of the proxy host and proxy port

### DIFF
--- a/lib/casclient/client.rb
+++ b/lib/casclient/client.rb
@@ -6,25 +6,25 @@ module CASClient
     attr_reader :ticket_store
     attr_writer :login_url, :validate_url, :proxy_url, :logout_url, :service_url
     attr_accessor :proxy_callback_url, :proxy_retrieval_url
-    
+
     def initialize(conf = nil)
       configure(conf) if conf
     end
-    
+
     def configure(conf)
       #TODO: raise error if conf contains unrecognized cas options (this would help detect user typos in the config)
 
       raise ArgumentError, "Missing :cas_base_url parameter!" unless conf[:cas_base_url]
-      
+
       if conf.has_key?("encode_extra_attributes_as")
         unless (conf[:encode_extra_attributes_as] == :json || conf[:encode_extra_attributes_as] == :yaml)
           raise ArgumentError, "Unkown Value for :encode_extra_attributes_as parameter! Allowed options are json or yaml - #{conf[:encode_extra_attributes_as]}"
         end
       end
-   
-      @cas_base_url      = conf[:cas_base_url].gsub(/\/$/, '')       
+
+      @cas_base_url      = conf[:cas_base_url].gsub(/\/$/, '')
       @cas_destination_logout_param_name = conf[:cas_destination_logout_param_name]
-      
+
       @login_url    = conf[:login_url]
       @logout_url   = conf[:logout_url]
       @validate_url = conf[:validate_url]
@@ -32,7 +32,11 @@ module CASClient
       @service_url  = conf[:service_url]
       @force_ssl_verification  = conf[:force_ssl_verification]
       @proxy_callback_url  = conf[:proxy_callback_url]
-      
+
+      #proxy server settings
+      @proxy_host = conf[:proxy_host]
+      @proxy_port = conf[:proxy_port]
+
       @username_session_key         = conf[:username_session_key] || :cas_user
       @extra_attributes_session_key = conf[:extra_attributes_session_key] || :cas_extra_attributes
       @ticket_store_class = case conf[:ticket_store]
@@ -45,13 +49,13 @@ module CASClient
       end
       @ticket_store = @ticket_store_class.new conf[:ticket_store_config]
       raise CASException, "The Ticket Store is not a subclass of AbstractTicketStore, it is a #{@ticket_store_class}" unless @ticket_store.kind_of? CASClient::Tickets::Storage::AbstractTicketStore
-      
+
       @log = CASClient::LoggerWrapper.new
       @log.set_real_logger(conf[:logger]) if conf[:logger]
       @ticket_store.log = @log
       @conf_options = conf
     end
-    
+
     def cas_destination_logout_param_name
       @cas_destination_logout_param_name || "destination"
     end
@@ -59,11 +63,11 @@ module CASClient
     def login_url
       @login_url || (cas_base_url + "/login")
     end
-    
+
     def validate_url
       @validate_url || (cas_base_url + "/proxyValidate")
     end
-    
+
     # Returns the CAS server's logout url.
     #
     # If a logout_url has not been explicitly configured,
@@ -72,14 +76,14 @@ module CASClient
     # destination_url:: Set this if you want the user to be
     #                   able to immediately log back in. Generally
     #                   you'll want to use something like <tt>request.referer</tt>.
-    #                   Note that the above behaviour describes RubyCAS-Server 
+    #                   Note that the above behaviour describes RubyCAS-Server
     #                   -- other CAS server implementations might use this
     #                   parameter differently (or not at all).
     # follow_url:: This satisfies section 2.3.1 of the CAS protocol spec.
     #              See http://www.ja-sig.org/products/cas/overview/protocol
     def logout_url(destination_url = nil, follow_url = nil)
       url = @logout_url || (cas_base_url + "/logout")
-      
+
       if destination_url
         # if present, remove the 'ticket' parameter from the destination_url
         duri = URI.parse(destination_url)
@@ -88,7 +92,7 @@ module CASClient
         duri.query = hash_to_query(h)
         destination_url = duri.to_s.gsub(/\?$/, '')
       end
-      
+
       if destination_url || follow_url
         uri = URI.parse(url)
         h = uri.query ? query_to_hash(uri.query) : {}
@@ -100,11 +104,11 @@ module CASClient
         url
       end
     end
-    
+
     def proxy_url
       @proxy_url || (cas_base_url + "/proxy")
     end
-    
+
     def validate_service_ticket(st)
       uri = URI.parse(validate_url)
       h = uri.query ? query_to_hash(uri.query) : {}
@@ -113,7 +117,7 @@ module CASClient
       h['renew'] = "1" if st.renew
       h['pgtUrl'] = proxy_callback_url if proxy_callback_url
       uri.query = hash_to_query(h)
-      
+
       response = request_cas_response(uri, ValidationResponse)
       st.user = response.user
       st.extra_attributes = response.extra_attributes
@@ -121,22 +125,22 @@ module CASClient
       st.success = response.is_success?
       st.failure_code = response.failure_code
       st.failure_message = response.failure_message
-      
+
       return st
     end
     alias validate_proxy_ticket validate_service_ticket
-    
+
     # Returns true if the configured CAS server is up and responding;
     # false otherwise.
     def cas_server_is_up?
       uri = URI.parse(login_url)
-      
+
       log.debug "Checking if CAS server at URI '#{uri}' is up..."
-      
-      https = Net::HTTP.new(uri.host, uri.port)
+
+      https = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(uri.host, uri.port)
       https.use_ssl = (uri.scheme == 'https')
       https.verify_mode = (@force_ssl_verification ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
-      
+
       begin
         raw_res = https.start do |conn|
           conn.get("#{uri.path}?#{uri.query}")
@@ -145,22 +149,22 @@ module CASClient
         log.warn "CAS server did not respond! (#{e.inspect})"
         return false
       end
-      
+
       log.debug "CAS server responded with #{raw_res.inspect}:\n#{raw_res.body}"
-      
+
       return raw_res.kind_of?(Net::HTTPSuccess)
     end
-    
-    # Requests a login using the given credentials for the given service; 
+
+    # Requests a login using the given credentials for the given service;
     # returns a LoginResponse object.
     def login_to_service(credentials, service)
       lt = request_login_ticket
-      
+
       data = credentials.merge(
         :lt => lt,
-        :service => service 
+        :service => service
       )
-      
+
       res = submit_data_to_cas(login_url, data)
       response = CASClient::LoginResponse.new(res)
 
@@ -170,7 +174,7 @@ module CASClient
 
       return response
     end
-  
+
     # Requests a login ticket from the CAS server for use in a login request;
     # returns a LoginTicket object.
     #
@@ -178,18 +182,18 @@ module CASClient
     # tickets in this manner is not part of the official CAS spec.
     def request_login_ticket
       uri = URI.parse(login_url+'Ticket')
-      https = Net::HTTP.new(uri.host, uri.port)
+      https = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(uri.host, uri.port)
       https.use_ssl = (uri.scheme == 'https')
       https.verify_mode = (@force_ssl_verification ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
       res = https.post(uri.path, ';')
-      
+
       raise CASException, res.body unless res.kind_of? Net::HTTPSuccess
-      
+
       res.body.strip
     end
-    
+
     # Requests a proxy ticket from the CAS server for the given service
-    # using the given pgt (proxy granting ticket); returns a ProxyTicket 
+    # using the given pgt (proxy granting ticket); returns a ProxyTicket
     # object.
     #
     # The pgt required to request a proxy ticket is obtained as part of
@@ -200,17 +204,17 @@ module CASClient
       h['pgt'] = pgt.ticket
       h['targetService'] = target_service
       uri.query = hash_to_query(h)
-      
+
       response = request_cas_response(uri, ProxyResponse)
-      
+
       pt = ProxyTicket.new(response.proxy_ticket, target_service)
       pt.success = response.is_success?
       pt.failure_code = response.failure_code
       pt.failure_message = response.failure_message
-      
+
       return pt
     end
-    
+
     def retrieve_proxy_granting_ticket(pgt_iou)
       pgt = @ticket_store.retrieve_pgt(pgt_iou)
 
@@ -218,24 +222,24 @@ module CASClient
 
       ProxyGrantingTicket.new(pgt, pgt_iou)
     end
-    
+
     def add_service_to_login_url(service_url)
       uri = URI.parse(login_url)
       uri.query = (uri.query ? uri.query + "&" : "") + "service=#{CGI.escape(service_url)}"
       uri.to_s
     end
-    
+
     private
     # Fetches a CAS response of the given type from the given URI.
     # Type should be either ValidationResponse or ProxyResponse.
     def request_cas_response(uri, type, options={})
       log.debug "Requesting CAS response for URI #{uri}"
-      
+
       uri = URI.parse(uri) unless uri.kind_of? URI
-      https = Net::HTTP.new(uri.host, uri.port)
+      https = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(uri.host, uri.port)
       https.use_ssl = (uri.scheme == 'https')
       https.verify_mode = (@force_ssl_verification ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
-      
+
       begin
         raw_res = https.start do |conn|
           conn.get("#{uri.path}?#{uri.query}")
@@ -244,7 +248,7 @@ module CASClient
         log.error "CAS server did not respond! (#{e.inspect})"
         raise "The CAS authentication server at #{uri} is not responding!"
       end
-      
+
       # We accept responses of type 422 since RubyCAS-Server generates these
       # in response to requests from the client that are processable but contain
       # invalid CAS data (for example an invalid service ticket).
@@ -254,25 +258,25 @@ module CASClient
         log.error "CAS server responded with an error! (#{raw_res.inspect})"
         raise "The CAS authentication server at #{uri} responded with an error (#{raw_res.inspect})!"
       end
-     
+
       type.new(raw_res.body, @conf_options)
     end
-    
+
     # Submits some data to the given URI and returns a Net::HTTPResponse.
     def submit_data_to_cas(uri, data)
       uri = URI.parse(uri) unless uri.kind_of? URI
       req = Net::HTTP::Post.new(uri.path)
       req.set_form_data(data, ';')
-      https = Net::HTTP.new(uri.host, uri.port)
+      https = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(uri.host, uri.port)
       https.use_ssl = (uri.scheme == 'https')
       https.verify_mode = (@force_ssl_verification ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
       https.start {|conn| conn.request(req) }
     end
-    
+
     def query_to_hash(query)
       CGI.parse(query)
     end
-      
+
     def hash_to_query(hash)
       pairs = []
       hash.each do |k, vals|


### PR DESCRIPTION
Adds configuration options for proxy_host and proxy_port, and uses Net::HTTP::Proxy instead of Net::HTTP so that it works for apps that are behind a proxy server
