### PR TITLE
Extra attribute parsing blows up when a blank attribute is not CDATA surrounded

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 group :development do
+  gem "json", "~> 1.6.1"
   gem "rspec", "~> 2.7.0"
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.6.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
+    json (1.6.1)
     rack (1.1.2)
     rake (0.9.2.2)
     rcov (0.9.11)
@@ -31,5 +32,6 @@ DEPENDENCIES
   activesupport
   bundler (~> 1.0.0)
   jeweler (~> 1.6.2)
+  json (~> 1.6.1)
   rcov
   rspec (~> 2.7.0)

--- a/lib/casclient/responses.rb
+++ b/lib/casclient/responses.rb
@@ -66,9 +66,7 @@ module CASClient
         
         @extra_attributes = {}
         @xml.elements.to_a('//cas:authenticationSuccess/cas:attributes/* | //cas:authenticationSuccess/*[local-name() != \'proxies\' and local-name() != \'proxyGrantingTicket\' and local-name() != \'user\' and local-name() != \'attributes\']').each do |el|
-          # generating the hash requires prefixes to be defined, so add all of the namespaces
-          el.namespaces.each {|k,v| el.add_namespace(k,v)}
-          @extra_attributes.merge!(Hash.from_xml(el.to_s))
+          @extra_attributes.merge! el.name => el.text
         end
         
         # unserialize extra attributes

--- a/spec/casclient/validation_response_spec.rb
+++ b/spec/casclient/validation_response_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'casclient/responses.rb'
+
+describe CASClient::ValidationResponse do
+  context "when parsing extra attributes as JSON" do
+    let(:response_text) do
+<<RESPONSE_TEXT
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+  <cas:authenticationSuccess>
+    <cas:attributes>
+      <cas:first_name>Jack</cas:first_name>
+      <cas:mobile_phone></cas:mobile_phone>
+      <cas:global_roles><![CDATA[]]></cas:global_roles>
+      <cas:foo_data><![CDATA[{ foo: "bar" }]]></cas:foo_data>
+    </cas:attributes>
+  </cas:authenticationSuccess>
+</cas:serviceResponse>
+RESPONSE_TEXT
+    end
+
+    let(:subject) { CASClient::ValidationResponse.new response_text, :encode_extra_attributes_as => :json }
+
+    it "sets the value of non-CDATA escaped empty attribute to nil" do
+      subject.extra_attributes["mobile_phone"].should be_nil
+    end
+
+    it "sets the value of CDATA escaped empty attribute to nil" do
+      subject.extra_attributes["global_roles"].should be_nil
+    end
+
+    it "sets the value of literal attributes to their value" do
+      subject.extra_attributes["first_name"].should == "Jack"
+    end
+
+    it "sets the value of JSON attributes to their parsed value" do
+      subject.extra_attributes["foo_data"]["foo"].should == "bar"
+    end
+  end
+end


### PR DESCRIPTION
This is actually due to a bug in ActiveSupport's Hash.from_xml, however eliminating use of the function seemed cleaner then working around or patching the issue.
