### PR TITLE
Added service param to logout url and passing gateway if destination param exists

### DIFF
--- a/lib/casclient/client.rb
+++ b/lib/casclient/client.rb
@@ -91,7 +91,7 @@ module CASClient
         duri.query = hash_to_query(dh)
         destination_url = duri.to_s.gsub(/\?$/, '')
         h[cas_destination_logout_param_name] = destination_url if destination_url
-        h[gateway] = 'true'
+        h['gateway'] = 'true'
       elsif follow_url
         h['url'] = follow_url if follow_url
         h['service'] = service_url


### PR DESCRIPTION
This allows the correct combination of params to be constructed into a URL to give you all of the behavioural options in rubycas-server logout.
