### PR TITLE
Fix for method not found 'ticket_name' on Nil when using CAS proxying with Rails 3

### DIFF
--- a/lib/casclient/frameworks/rails/cas_proxy_callback_controller.rb
+++ b/lib/casclient/frameworks/rails/cas_proxy_callback_controller.rb
@@ -22,8 +22,12 @@ class CasProxyCallbackController < ActionController::Base
     render :text => "Okay, the server is up, but please specify a pgtIou and pgtId." and return unless pgtIou and pgtId
     
     # TODO: pstore contents should probably be encrypted...
-    
-    casclient = CASClient::Frameworks::Rails::Filter.client
+
+    if Rails::VERSION::MAJOR > 2
+      casclient = RubyCAS::Filter.client
+    else
+      casclient = CASClient::Frameworks::Rails::Filter.client
+    end
 
     casclient.ticket_store.save_pgt_iou(pgtIou, pgtId)
 


### PR DESCRIPTION
Rails 3 uses the rubycas-client-rails gem instead of
the Rails code in this gem, so a proper fix would be to move
CasProxyCallbackController into rubycas-client-rails, but this should
be a safe interim fix.
