### PR TITLE
Prevents to_sym getting called on nil from within Filter#unauthorized!

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -218,7 +218,10 @@ module CASClient
           end
           
           def unauthorized!(controller, vr = nil)
-            format = controller.request.format.to_sym
+            format = nil
+            unless controller.request.format.nil?
+              format = controller.request.format.to_sym
+            end
             format = (format == :js ? :json : format)
             case format
             when :xml, :json

--- a/spec/casclient/frameworks/rails/filter_spec.rb
+++ b/spec/casclient/frameworks/rails/filter_spec.rb
@@ -182,4 +182,21 @@ describe CASClient::Frameworks::Rails::Filter do
       end
     end
   end
+
+  context "controller request is missing format" do
+    context "#unauthorized!" do
+      it 'should not crash' do
+        request = double('mock request')
+        request.stub(:format).and_return(nil)
+
+        controller = controller_with_session(request)
+
+        CASClient::Frameworks::Rails::Filter.
+          should_receive(:redirect_to_cas_for_authentication).
+          with(controller)
+          
+        CASClient::Frameworks::Rails::Filter.unauthorized!(controller)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If controller.request.format is nil, then Filter#unauthorized! generates an exception when #to_sym is called on nil.
