### PR TITLE
Adds support for another way to show cas xml attributes.

### DIFF
--- a/lib/casclient/responses.rb
+++ b/lib/casclient/responses.rb
@@ -67,7 +67,12 @@ module CASClient
         @extra_attributes = {}
         @xml.elements.to_a('//cas:authenticationSuccess/cas:attributes/* | //cas:authenticationSuccess/*[local-name() != \'proxies\' and local-name() != \'proxyGrantingTicket\' and local-name() != \'user\' and local-name() != \'attributes\']').each do |el|
           inner_text = el.cdatas.length > 0 ? el.cdatas.join('') : el.text
-          @extra_attributes.merge! el.name => inner_text
+          name = el.name
+          unless (attrs = el.attributes).empty?
+            name       = attrs['name']
+            inner_text = attrs['value']
+          end
+          @extra_attributes.merge! name => inner_text
         end
         
         # unserialize extra attributes

--- a/spec/casclient/validation_response_spec.rb
+++ b/spec/casclient/validation_response_spec.rb
@@ -21,7 +21,22 @@ describe CASClient::ValidationResponse do
 RESPONSE_TEXT
     end
 
+    let(:other_response_text) do
+<<RESPONSE_TEXT
+<?xml version="1.0" encoding="UTF-8"?>
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+  <cas:authenticationSuccess>
+    <cas:user>myuser</cas:user>
+    <cas:attribute name="username" value="myuser"/>
+    <cas:attribute name="name" value="My User"/>
+    <cas:attribute name="email" value="myuser@mail.example.com"/>
+  </cas:authenticationSuccess>
+</cas:serviceResponse>
+RESPONSE_TEXT
+    end
+
     let(:subject) { CASClient::ValidationResponse.new response_text, :encode_extra_attributes_as => :json }
+    let(:other_subject) { CASClient::ValidationResponse.new other_response_text }
 
     it "sets the value of non-CDATA escaped empty attribute to nil" do
       subject.extra_attributes["mobile_phone"].should be_nil
@@ -49,6 +64,12 @@ RESPONSE_TEXT
 
     it "sets the value of attributes which are not valid JSON but are valid YAML to their literal value" do
       subject.extra_attributes["allegedly_yaml"].should == '- 10'
+    end
+
+    it "sets attributes for other type of format" do
+      expected = {"username" => "myuser", "name" => 'My User', "email" => 'myuser@mail.example.com'}
+      other_subject.user.should == 'myuser'
+      other_subject.extra_attributes.should == expected
     end
   end
 end


### PR DESCRIPTION
our CAS server is returning xml in a different format. I'm not very familiar with xml, so I'm not totally sure what the best way is to support both formats, but the tests pass :)
