### PR TITLE
Create the tmp/sessions dir if it doesn't exist

### DIFF
--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 module CASClient
   module Tickets
     module Storage
@@ -84,6 +86,7 @@ module CASClient
           @tmp_dir = config[:storage_dir] || default_tmp_dir
           @service_session_lookup_dir = config[:service_session_lookup_dir] || "#{@tmp_dir}/sessions"
           @pgt_store_path = config[:pgt_store_path] || "#{@tmp_dir}/cas_pgt.pstore"
+          create_service_session_lookup_dir
         end
 
         # Creates a file in tmp/sessions linking a SessionTicket
@@ -168,6 +171,12 @@ module CASClient
 
         def open_pstore
           PStore.new(@pgt_store_path)
+        end
+
+        def create_service_session_lookup_dir
+          unless File.exist? @service_session_lookup_dir
+            FileUtils.mkdir_p @service_session_lookup_dir
+          end
         end
       end
     end

--- a/spec/casclient/tickets/storage_spec.rb
+++ b/spec/casclient/tickets/storage_spec.rb
@@ -32,13 +32,28 @@ end
 
 describe CASClient::Tickets::Storage::LocalDirTicketStore do
   let(:dir) {File.join(SPEC_TMP_DIR, "local_dir_ticket_store")}
-  before do
-    FileUtils.mkdir_p(File.join(dir, "sessions"))
-  end
+
   after do
     FileUtils.remove_dir(dir)
   end
-  it_should_behave_like "a ticket store" do
-    let(:ticket_store) {described_class.new(:storage_dir => dir)}
+
+  describe "when the sessions directory does not exist" do
+    before do
+      File.exist?(File.join(dir, "sessions")).should be_false
+    end
+
+    it_should_behave_like "a ticket store" do
+      let(:ticket_store) {described_class.new(:storage_dir => dir)}
+    end
+  end
+
+  describe "when the session directory exists" do
+    before do
+      FileUtils.mkdir_p(File.join(dir, "sessions"))
+    end
+
+    it_should_behave_like "a ticket store" do
+      let(:ticket_store) {described_class.new(:storage_dir => dir)}
+    end
   end
 end


### PR DESCRIPTION
Given that the directory is temporary, it seems reasonable to silently create it if it doesn't already exist. This just tripped me up because our deployment script wasn't creating the directory.
