### PR TITLE
Fix bug #42 where we are unable to programmatically authenticate

### DIFF
--- a/lib/casclient/responses.rb
+++ b/lib/casclient/responses.rb
@@ -190,8 +190,15 @@ module CASClient
       if location =~ /ticket=([^&]+)/
         @ticket = $~[1]
       end
-
-      unless http_response.kind_of?(Net::HTTPSeeOther) && @ticket.present?
+      
+      # Legacy check. CAS Server used to return a 200 (Success) or a 302 (Found) on successful authentication.
+      # This behavior should be deprecated at some point in the future.
+      legacy_valid_ticket = (http_response.kind_of?(Net::HTTPSuccess) || http_response.kind_of?(Net::HTTPFound)) && @ticket.present?
+      
+      # If using rubycas-server 1.1.0+
+      valid_ticket = http_response.kind_of?(Net::HTTPSeeOther) && @ticket.present?
+      
+      if !legacy_valid_ticket && !valid_ticket
         @failure = true
         # Try to extract the error message -- this only works with RubyCAS-Server.
         # For other servers we just return the entire response body (i.e. the whole error page).


### PR DESCRIPTION
The HTTPSeeOther is the response status that is emitted from the server on successful authentication.
