### PR TITLE
revise default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,6 @@ require 'appraisal'
 
 require 'rspec/core/rake_task'
 desc 'Default: run the specs and features.'
-task :default do
-  system("bundle exec rake -s appraisal spec ;")
-end
+task :default => [:spec]
 
 RSpec::Core::RakeTask.new


### PR DESCRIPTION
Appraisal runs the default task unless you specify
what task to run. This isn't a problem as long as
you always specify what task to run but if you
don't it ends up repeatedly running the specs with
the rails23 gemset.

Signed-off-by: Tyler Pickett t.pickett66@gmail.com
