### PR TITLE
Fix for failure during CAS single sign out when ActiveRecord::SessionStore is not used

### DIFF
--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -28,8 +28,11 @@ module CASClient
         def get_session_for_service_ticket(st)
           session_id = read_service_session_lookup(st)
           unless session_id.nil?
-            # This feels a bit hackish, but there isn't really a better way to go about it that I am aware of yet
-            session = ActiveRecord::SessionStore.session_class.find_by_session_id(session_id)
+            # Try to access session store only if it is the configured session store
+            if ::Rails.application.config.session_store == ActiveRecord::SessionStore
+              # This feels a bit hackish, but there isn't really a better way to go about it that I am aware of yet
+              session = ActiveRecord::SessionStore.session_class.find_by_session_id(session_id)
+            end
           else
             log.warn("Couldn't destroy session service ticket #{st} because no corresponding session id could be found.")
           end


### PR DESCRIPTION
When anyother session store (ActionDispatch::Session::CookieStore) is used by the Rails app, the single sign out POST request sent by the CAS server ends up in the following exception

---

ActiveRecord::StatementInvalid (PG::Error: ERROR:  relation "sessions" does not exist
LINE 4:              WHERE a.attrelid = '"sessions"'::regclass
                                        ^
:             SELECT a.attname, format_type(a.atttypid, a.atttypmod), d.adsrc, a.attnotnull
              FROM pg_attribute a LEFT JOIN pg_attrdef d
                ON a.attrelid = d.adrelid AND a.attnum = d.adnum
             WHERE a.attrelid = '"sessions"'::regclass
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum
):
.
.
.
activerecord (3.2.6) lib/active_record/session_store.rb:98:in `find_by_session_id'
rubycas-client (2.3.9) lib/casclient/tickets/storage.rb:32:in`get_session_for_service_ticket'
rubycas-client (2.3.9) lib/casclient/tickets/storage.rb:13:in `process_single_sign_out'
rubycas-client (2.3.9) lib/casclient/frameworks/rails/filter.rb:300:in`single_sign_out'
rubycas-client (2.3.9) lib/casclient/frameworks/rails/filter.rb:28:in `filter'
.
.
## .

Which is correct because there will not be any sessions table if ActiveRecord::SessionStore is not used

Ref: https://wiki.jasig.org/display/CASUM/Single+Sign+Out
