### PR TITLE
Updated CAS controller to remove RubyCAS::Filter.client

### DIFF
--- a/lib/casclient/frameworks/rails/cas_proxy_callback_controller.rb
+++ b/lib/casclient/frameworks/rails/cas_proxy_callback_controller.rb
@@ -22,12 +22,7 @@ class CasProxyCallbackController < ActionController::Base
     render :text => "Okay, the server is up, but please specify a pgtIou and pgtId." and return unless pgtIou and pgtId
     
     # TODO: pstore contents should probably be encrypted...
-
-    if Rails::VERSION::MAJOR > 2
-      casclient = RubyCAS::Filter.client
-    else
-      casclient = CASClient::Frameworks::Rails::Filter.client
-    end
+    casclient = CASClient::Frameworks::Rails::Filter.client
 
     casclient.ticket_store.save_pgt_iou(pgtIou, pgtId)
 


### PR DESCRIPTION
As far as I can tell the RubyCAS-client-rails gem is broken under rails 3+ (or at least 3.1). In fact RubyCAS-client works great in all aspects WITHOUT RubyCAS-client-rails. This was the only issue I had run into and removing it resolved all of my problems.

If this is necessary in other places please make a suggestion to resolve this issue as I don't want to break other users of this gem.
