### PR TITLE
Single sign off not working as expected with authenticate on every request disabled

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -297,7 +297,11 @@ module CASClient
               
               log.debug "Intercepted single-sign-out request for CAS session #{si.inspect}."
 
-              @@client.ticket_store.process_single_sign_out(si)
+              if config[:authenticate_on_every_request]
+                @@client.ticket_store.process_single_sign_out(si)
+              else
+                logout(controller)
+              end
               
               # Return true to indicate that a single-sign-out request was detected
               # and that further processing of the request is unnecessary.


### PR DESCRIPTION
When using single sign off the RubyCAS gem looks for the ticket passed
to the web application in the logout message. Unfortunately this will
be the latest ticket rather than the ticket the web application is most
likely using when authenticate_on_every_request is disabled making it impossible to end the current session.

This change looks at the authenticate_on_every_request configuration
property to choose the correct experience to avoid the issue with
single sign off enabled and authenticate on every request disabled.

Arguably maybe logoff should always be called; I'm not sure what would be most appropriate with CAS but this change resolved our sign off issues so please let me know if there are any glaring omissions here.