### PR TITLE
move ActiveRecord dependency into ActiveRecordTicketStore

### DIFF
--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -116,8 +116,9 @@ module CASClient
         def destroy_session_with_session_id session_id, st
           raise CASException, "No service_ticket specified." if st.nil?
 
-          session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
-          session.destroy if session.present?
+          st = st.ticket if st.kind_of? ServiceTicket
+          ssl_filename = filename_of_service_session_lookup(st)
+          File.delete(ssl_filename) if File.exists?(ssl_filename)
         end
 
         # Removes a stored relationship between a ServiceTicket and a local

--- a/lib/casclient/tickets/storage.rb
+++ b/lib/casclient/tickets/storage.rb
@@ -116,9 +116,8 @@ module CASClient
         def destroy_session_with_session_id session_id, st
           raise CASException, "No service_ticket specified." if st.nil?
 
-          st = st.ticket if st.kind_of? ServiceTicket
-          ssl_filename = filename_of_service_session_lookup(st)
-          File.delete(ssl_filename) # if File.exists?(ssl_filename)
+          session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
+          session.destroy if session.present?
         end
 
         # Removes a stored relationship between a ServiceTicket and a local

--- a/lib/casclient/tickets/storage/active_record_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_record_ticket_store.rb
@@ -9,7 +9,7 @@ module CASClient
       # Proxy Granting Tickets and their IOUs are stored in the cas_pgtious table.
       #
       # This ticket store takes the following config parameters
-      # :pgtious_table_name - the name of the table 
+      # :pgtious_table_name - the name of the table
       class ActiveRecordTicketStore < AbstractTicketStore
 
         def initialize(config={})
@@ -27,6 +27,12 @@ module CASClient
           st = st.ticket if st.kind_of? ServiceTicket
           session = controller.session
           session[:service_ticket] = st
+        end
+
+        def destroy_session_with_session_id session_id, st
+          # This feels a bit hackish, but there isn't really a better way to go about it that I am aware of yet
+          session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
+          session.destroy
         end
 
         def read_service_session_lookup(st)

--- a/lib/casclient/tickets/storage/active_record_ticket_store.rb
+++ b/lib/casclient/tickets/storage/active_record_ticket_store.rb
@@ -32,7 +32,7 @@ module CASClient
         def destroy_session_with_session_id session_id, st
           # This feels a bit hackish, but there isn't really a better way to go about it that I am aware of yet
           session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
-          session.destroy
+          session.destroy if session.present?
         end
 
         def read_service_session_lookup(st)

--- a/spec/casclient/tickets/storage_spec.rb
+++ b/spec/casclient/tickets/storage_spec.rb
@@ -23,9 +23,9 @@ describe CASClient::Tickets::Storage::AbstractTicketStore do
       expect { subject.retrieve_pgt("pgt_iou") }.to raise_exception 'Implement this in a subclass!'
     end
   end
-  describe "#get_session_for_service_ticket" do
+  describe "#get_session_id_for_service_ticket" do
     it "should raise an exception" do
-      expect { subject.get_session_for_service_ticket("service_ticket") }.to raise_exception 'Implement this in a subclass!'
+      expect { subject.get_session_id_for_service_ticket("service_ticket") }.to raise_exception 'Implement this in a subclass!'
     end
   end
 end

--- a/spec/casclient/tickets/storage_spec.rb
+++ b/spec/casclient/tickets/storage_spec.rb
@@ -8,6 +8,11 @@ describe CASClient::Tickets::Storage::AbstractTicketStore do
       expect { subject.store_service_session_lookup("service_ticket", mock_controller_with_session) }.to raise_exception 'Implement this in a subclass!'
     end
   end
+  describe "#destroy_session_with_session_id" do
+    it "should raise an exception" do
+      expect { subject.destroy_session_with_session_id("service_ticket", nil) }.to raise_exception 'Implement this in a subclass!'
+    end
+  end
   describe "#cleanup_service_session_lookup" do
     it "should raise an exception" do
       expect { subject.cleanup_service_session_lookup("service_ticket") }.to raise_exception 'Implement this in a subclass!'

--- a/spec/support/local_hash_ticket_store.rb
+++ b/spec/support/local_hash_ticket_store.rb
@@ -19,6 +19,15 @@ class LocalHashTicketStore < CASClient::Tickets::Storage::AbstractTicketStore
     st_hash[st]
   end
 
+  def destroy_session_with_session_id session_id, st
+    raise CASClient::CASException, "No service_ticket specified." if st.nil?
+    st = st.ticket if st.kind_of? CASClient::ServiceTicket
+    st_hash.delete st
+
+    session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
+    session.destroy if session.present?
+  end
+
   def cleanup_service_session_lookup(st)
     raise CASClient::CASException, "No service_ticket specified." if st.nil?
     st = st.ticket if st.kind_of? CASClient::ServiceTicket

--- a/spec/support/local_hash_ticket_store.rb
+++ b/spec/support/local_hash_ticket_store.rb
@@ -23,9 +23,6 @@ class LocalHashTicketStore < CASClient::Tickets::Storage::AbstractTicketStore
     raise CASClient::CASException, "No service_ticket specified." if st.nil?
     st = st.ticket if st.kind_of? CASClient::ServiceTicket
     st_hash.delete st
-
-    session = ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session_id})
-    session.destroy if session.present?
   end
 
   def cleanup_service_session_lookup(st)

--- a/spec/support/shared_examples_for_ticket_stores.rb
+++ b/spec/support/shared_examples_for_ticket_stores.rb
@@ -11,10 +11,10 @@ shared_examples "a ticket store interacting with sessions" do
     end
   end
 
-  describe "#get_session_for_service_ticket" do
+  describe "#get_session_id_for_service_ticket" do
     context "the service ticket is nil" do
       it "should raise CASException" do
-        expect { subject.get_session_for_service_ticket(nil) }.to raise_exception(CASClient::CASException, /No service_ticket specified/)
+        expect { subject.get_session_id_for_service_ticket(nil) }.to raise_exception(CASClient::CASException, /No service_ticket specified/)
       end
     end
     context "the service ticket is associated with a session" do
@@ -23,15 +23,13 @@ shared_examples "a ticket store interacting with sessions" do
         session.save!
       end
       it "should return the session_id and session for the given service ticket" do
-        result_session_id, result_session = subject.get_session_for_service_ticket(service_ticket)
+        result_session_id = subject.get_session_id_for_service_ticket(service_ticket)
         result_session_id.should == session.session_id
-        result_session.session_id.should == session.session_id
-        result_session.data.should == session.data
       end
     end
     context "the service ticket is not associated with a session" do
       it "should return nils if there is no session for the given service ticket" do
-        subject.get_session_for_service_ticket(service_ticket).should == [nil, nil]
+        subject.get_session_id_for_service_ticket(service_ticket).should == nil
       end
     end
   end

--- a/spec/support/shared_examples_for_ticket_stores.rb
+++ b/spec/support/shared_examples_for_ticket_stores.rb
@@ -48,7 +48,7 @@ shared_examples "a ticket store interacting with sessions" do
       end
       context "the session" do
         it "should be destroyed" do
-          ActiveRecord::SessionStore.session_class.find(:first, :conditions => {:session_id => session.session_id}).should be_nil
+          subject.get_session_id_for_service_ticket(service_ticket).should be_nil
         end
       end
       it "should destroy session for the given service ticket" do


### PR DESCRIPTION
The `AbstractTicketStore` should not be coupled to any storage engine at all because it's supposed to be _abstract_. Thus, I've introduced the method `destroy_session_with_session_id(session_id, st)` which needs to be implemented per TicketStore subclass.

With this change it's quite easy to enable single sign out using redis-store and no shared tmp sessions directory.

The tests are not green yet for the `LocalDirTicketStore` but hopefully I can fix this tomorrow.

If you like I'd create a second pr after this one which contains a RedisTicketStore implementation, as it eased the single sign out integration for me.

thank you :)
