### PR TITLE
Explicitly test for ActionController::Base in addition to Rails

### DIFF
--- a/lib/casclient.rb
+++ b/lib/casclient.rb
@@ -68,7 +68,7 @@ require 'casclient/responses'
 require 'casclient/client'
 require 'casclient/tickets/storage'
 autoload :ACTIVE_RECORD_TICKET_STORE, 'casclient/tickets/storage/active_record_ticket_store'
-if defined?(Rails)
+if defined?(Rails) && defined?(ActionController::Base)
   require 'casclient/frameworks/rails/filter'
   require 'casclient/frameworks/rails/cas_proxy_callback_controller'
 end


### PR DESCRIPTION
We use rubycas-client in a Rack-based project where we use do ActiveRecord, but not ActionController. In combination with standalone-migrations (which does a require on Rails to get ActiveRecord + migrations code loaded), this creates the situation where:
- Rails is defined
- ActionController is not defined

rubycas-client does a check if Rails is defined, and if so it goes ahead and loads the Rails-specific extensions.

The problem here is that the rubycas-client Rails extensions are actually for ActionController, which is _usually_ included when Rails exists, but not always (as in our situation).

I've included a patch which checks explicitly for ActionController::Base in addition to Rails, prior to attempting to load the Rails extensions.

Can the code be merged into master?
