### PR TITLE
Update to Rails 4.1

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -11,7 +11,7 @@ module CASClient
         @@fake_user = nil
         @@fake_extra_attributes = nil
 
-        def before(controller)
+        def self.before(controller)
           self.filter controller
         end
         


### PR DESCRIPTION
For some reasons, Rails 4,1+ need the filter to have a action method, like when used with `before_action`, the filter need to have a `before` method, so does `after_action`, etc..

This is an addition of `before` method. Now it passed the test under Rails 4.1.rc1.
You can simply merge this PR.
