### PR TITLE
make ticket_url configurable

### DIFF
--- a/lib/casclient/client.rb
+++ b/lib/casclient/client.rb
@@ -5,7 +5,7 @@ module CASClient
     attr_reader :log, :username_session_key, :extra_attributes_session_key
     attr_reader :ticket_store
     attr_reader :proxy_host, :proxy_port
-    attr_writer :login_url, :validate_url, :proxy_url, :logout_url, :service_url
+    attr_writer :login_url, :validate_url, :proxy_url, :logout_url, :service_url, :ticket_url
     attr_accessor :proxy_callback_url, :proxy_retrieval_url
 
     def initialize(conf = nil)
@@ -28,6 +28,7 @@ module CASClient
 
       @login_url    = conf[:login_url]
       @logout_url   = conf[:logout_url]
+      @ticket_url   = conf[:ticket_url]
       @validate_url = conf[:validate_url]
       @proxy_url    = conf[:proxy_url]
       @service_url  = conf[:service_url]
@@ -68,6 +69,10 @@ module CASClient
 
     def validate_url
       @validate_url || (cas_base_url + "/proxyValidate")
+    end
+
+    def ticket_url
+      @ticket_url || (cas_base_url + '/loginTicket')
     end
 
     # Returns the CAS server's logout url.
@@ -182,7 +187,7 @@ module CASClient
     # This only works with RubyCAS-Server, since obtaining login
     # tickets in this manner is not part of the official CAS spec.
     def request_login_ticket
-      uri = URI.parse(login_url+'Ticket')
+      uri = URI.parse(ticket_url)
       https = https_connection(uri)
       res = https.post(uri.path, ';')
 

--- a/spec/casclient/client_spec.rb
+++ b/spec/casclient/client_spec.rb
@@ -53,7 +53,7 @@ describe CASClient::Client do
     
     context "request login ticket" do
       it "raises an exception when the request was not a success" do
-        session.stub(:post).with("/Ticket", ";").and_return(response)
+        session.stub(:post).with("/loginTicket", ";").and_return(response)
         response.stub :kind_of? => false
         lambda {
           client.request_login_ticket
@@ -61,7 +61,7 @@ describe CASClient::Client do
       end
       
       it "returns the response body when the request is a success" do
-        session.stub(:post).with("/Ticket", ";").and_return(response)
+        session.stub(:post).with("/loginTicket", ";").and_return(response)
         response.stub :kind_of? => true
         client.request_login_ticket.should == "HTTP BODY"
       end


### PR DESCRIPTION
I've moved the `ticket_url` to separate method and added it to config options. Using the `cas_base_url` for composition the login ticket url is more correct then login_url.

Best regards,
Sergey
