### PR TITLE
Add service url configuration to the list

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -138,7 +138,7 @@ An arbitrary Logger instance can be given as the :logger parameter. In the examp
 <tt>log/cas.log</tt> file in your Rails app's directory.
 
 The service url sets the service parameter that will be sent to CAS for every authentication.  This can be useful if you are 
-implementing the single logout feature or would like to funnel all authentications through a specific action.
+implementing the single logout feature (supported by some CAS Servers) or would like to funnel all authentications through a specific action.
 
 ==== Re-authenticating on every request (i.e. the "single sign-out problem")
 


### PR DESCRIPTION
Not sure if this is intentionally left undocumented, but I found this very useful when working with a CAS server that enabled the single logout functionality.  The issue was that on logout the CAS server would post to the service url.  If we had a bunch of potential urls it made our route configuration very challenging.  While implementing something to funnel all authentications through a single action, I discovered this config param.  This allowed us to use session to store the redirect path and route all CAS authentications through a single 'service'

I'm not sure if this is an intended use or not, but since the configuration parameter existed I thought adding it to the readme might be helpful. Sorry for the two commits -- please squash.
