### PR TITLE
Allow users to specify SSL version when using  CASClient::Client

### DIFF
--- a/lib/casclient/client.rb
+++ b/lib/casclient/client.rb
@@ -31,6 +31,7 @@ module CASClient
       @validate_url = conf[:validate_url]
       @proxy_url    = conf[:proxy_url]
       @service_url  = conf[:service_url]
+      @ssl_version  = conf[:ssl_version]
       @force_ssl_verification  = conf[:force_ssl_verification]
       @proxy_callback_url  = conf[:proxy_callback_url]
 
@@ -233,6 +234,7 @@ module CASClient
     def https_connection(uri)
       https = Net::HTTP::Proxy(proxy_host, proxy_port).new(uri.host, uri.port)
       https.use_ssl = (uri.scheme == 'https')
+      https.ssl_version = @ssl_version if @ssl_version
       https.verify_mode = (@force_ssl_verification ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
       https
     end


### PR DESCRIPTION
The `DEFAULT_PARAMS` constant defined by `OpenSSL::SSL::SSLContext` indicates that instances of this class will use "SSLv23" by default. I ran a number of tests and now I believe that the most secure version (supported) of the protocol is what is actually used. This means that client systems using openssl v1.0.1 will default to TLS v1.2.

Unfortunately, a large number of CAS servers do not support communication using TLS v1.1. or v1.2. Hence, we need a way to configure a different protocol version when and where necessary. The enhancement provides that option while maintaining the original behavior when it is unspecified.
