### PR TITLE
Fix ArgumentError: comparison of String with Time failed error for pr…

### DIFF
--- a/lib/casclient/frameworks/rails/filter.rb
+++ b/lib/casclient/frameworks/rails/filter.rb
@@ -255,7 +255,7 @@ module CASClient
             end
             
             if controller.session[:previous_redirect_to_cas] &&
-                controller.session[:previous_redirect_to_cas] > (Time.now - 1.second)
+                controller.session[:previous_redirect_to_cas].to_time > (Time.now - 1.second)
               log.warn("Previous redirect to the CAS server was less than a second ago. The client at #{controller.request.remote_ip.inspect} may be stuck in a redirection loop!")
               controller.session[:cas_validation_retry_count] ||= 0
               


### PR DESCRIPTION
ArgumentError: comparison of String with Time failed on Rails 3 and Rails 4.

detail:

ArgumentError: comparison of String with Time failed
	from (irb):1:in `>'
	from (irb):1
	from /Users/kingjim/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/railties-4.1.6/lib/rails/commands/console.rb:90:in `start'
	from /Users/kingjim/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/railties-4.1.6/lib/rails/commands/console.rb:9:in `start'
	from /Users/kingjim/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/railties-4.1.6/lib/rails/commands/commands_tasks.rb:69:in `console'
	from /Users/kingjim/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/railties-4.1.6/lib/rails/commands/commands_tasks.rb:40:in `run_command!'
	from /Users/kingjim/.rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/railties-4.1.6/lib/rails/commands.rb:17:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'